### PR TITLE
fix: 인라인 onclick 핸들러 제거 및 Timer 정리 로직 개선

### DIFF
--- a/js/modules/site-info-ui.js
+++ b/js/modules/site-info-ui.js
@@ -5,6 +5,12 @@
 import { config } from '../data/config.js';
 import { getRequiredElement, setupEmailCopy } from './utils.js';
 
+// 클릭 애니메이션 타이밍 상수
+const CLICK_ANIMATION_DURATION = 300;
+
+// 소셜 링크별 타이머를 저장하는 WeakMap (메모리 누수 방지)
+const socialLinkTimers = new WeakMap();
+
 /**
  * Contact 섹션의 정보를 동적으로 렌더링합니다.
  */
@@ -34,7 +40,7 @@ function renderContactInfo() {
                 <a href="${social.url}"
                 target="_blank"
                 rel="noopener noreferrer"
-                onclick="this.classList.add('clicking'); setTimeout(() => this.classList.remove('clicking'), 300);">
+                class="social-link">
                     ${social.handle}
                 </a>
             </p>
@@ -42,6 +48,49 @@ function renderContactInfo() {
     `).join('');
 
     contactContainer.innerHTML = emailHTML + socialsHTML;
+}
+
+/**
+ * 소셜 링크 클릭 애니메이션을 설정합니다.
+ * 인라인 onclick 핸들러를 대체하여 CSP 호환성 및 타이머 정리를 개선합니다.
+ */
+function setupSocialLinkClickAnimation() {
+    const socialLinks = document.querySelectorAll('.contact-item a.social-link');
+
+    socialLinks.forEach(link => {
+        link.addEventListener('click', () => {
+            // 기존 타이머가 있으면 정리 (다중 클릭 시 중첩 방지)
+            const existingTimer = socialLinkTimers.get(link);
+            if (existingTimer) {
+                clearTimeout(existingTimer);
+            }
+
+            // 클릭 애니메이션 클래스 추가
+            link.classList.add('clicking');
+
+            // 타이머 설정 및 ID 저장
+            const timerId = setTimeout(() => {
+                link.classList.remove('clicking');
+                socialLinkTimers.delete(link);
+            }, CLICK_ANIMATION_DURATION);
+
+            socialLinkTimers.set(link, timerId);
+        });
+    });
+}
+
+/**
+ * 소셜 링크 타이머 정리 (페이지 언로드 시 호출)
+ */
+function cleanupSocialLinkTimers() {
+    const socialLinks = document.querySelectorAll('.contact-item a.social-link');
+    socialLinks.forEach(link => {
+        const timerId = socialLinkTimers.get(link);
+        if (timerId) {
+            clearTimeout(timerId);
+            socialLinkTimers.delete(link);
+        }
+    });
 }
 
 /**
@@ -75,8 +124,12 @@ export function initSiteInfoUI() {
     renderContactInfo();
     renderFooter();
 
-    // Contact 정보 렌더링 후 이메일 복사 이벤트 리스너 설정
+    // Contact 정보 렌더링 후 이벤트 리스너 설정
     setupEmailCopy();
+    setupSocialLinkClickAnimation();
+
+    // 페이지 언로드 시 타이머 정리
+    window.addEventListener('beforeunload', cleanupSocialLinkTimers);
 
     console.log(' Site Info UI module initialized');
 }


### PR DESCRIPTION
## 개요 (Overview)
- 소셜 링크의 인라인 `onclick` 핸들러를 `addEventListener` 방식으로 변경하여 CSP 호환성 및 코드 유지보수성을 개선
- `WeakMap` 기반 타이머 관리 로직을 추가하여 메모리 누수 가능성 제거

## 주요 변경 사항 (Key Changes)
- `site-info-ui.js`: 인라인 `onclick` 속성 제거, `class="social-link"` 추가
- `setupSocialLinkClickAnimation()`: 이벤트 리스너 기반 클릭 애니메이션 설정 함수
- `WeakMap`: 요소별 타이머 ID 저장 (다중 클릭 시 기존 타이머 정리로 중첩 방지)
- `cleanupSocialLinkTimers()`: 페이지 언로드 시 타이머 정리 함수
- `beforeunload` 이벤트 등록으로 타이머 정리 보장

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
- **테스트 시나리오:**
  - 소셜 링크 단일 클릭 시 애니메이션 동작 확인
  - 300ms 내 다중 클릭 시 타이머 중첩 없이 정상 동작
  - 이메일 링크 기존 동작 유지

- **검증 결과:**
  - 브라우저 테스트 완료 (localhost:8082)
  - Console 에러 없음
  - Site Info UI module initialized 정상 출력

```
[LOG]  Site Info UI module initialized @ site-info-ui.js:133
```

## 연관 이슈 (Linked Issues)
- Closes #2
- Closes #3